### PR TITLE
Made papersize configurable per language

### DIFF
--- a/input/metadata.yaml
+++ b/input/metadata.yaml
@@ -5,6 +5,7 @@ de:
     - Tobias Dussa
   pdf_link_text: Als PDF herunterladen
   other_lang_text: Andere Sprachen
+  papersize: A4
 
 en:
   title: A VisiData Cheat Sheet 
@@ -13,6 +14,7 @@ en:
     - Jeremy Singer-Vine
   pdf_link_text: Download the One-Page PDF
   other_lang_text: Other languages
+  papersize: Letter
 
 es:
   title: Un "Cheat Sheet" Para VisiData
@@ -22,6 +24,7 @@ es:
     - Data Crítica
   pdf_link_text: Descargar la Versión PDF
   other_lang_text: Otras idiomas
+  papersize: A4
 
 it:
   title: VisiData Cheat Sheet
@@ -30,3 +33,4 @@ it:
     - Associazione onData
   pdf_link_text: Scarica la versione in PDF
   other_lang_text: Altri linguaggi
+  papersize: A4

--- a/input/template.html
+++ b/input/template.html
@@ -109,7 +109,7 @@
     }
 
     @page {
-        size: Letter;
+        size: {{papersize}};
         margin: 0.1in;
     }
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -45,6 +45,7 @@ def main():
             meta = meta[lang],
             lang = lang,
             all_langs = list(langs),
+            papersize = meta[lang]['papersize'],
         )
 
         if args.stdout:


### PR DESCRIPTION
The paper size is now configurable per language in `input/metadata.yml`.  By default, the paper size is set to Letter for English and to A4 for German, Italian, and Spanish.

Fixes #24.